### PR TITLE
Update fsnotify import path

### DIFF
--- a/recwatch.go
+++ b/recwatch.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-fsnotify/fsnotify"
+	"github.com/fsnotify/fsnotify"
 )
 
 type Event fsnotify.Event


### PR DESCRIPTION
The go-notify organization was renamed to just "fsnotify".
